### PR TITLE
Use a bounded memory uniform sampling reservoir

### DIFF
--- a/src/main/java/org/radarcns/stream/collector/NumericAggregateCollector.java
+++ b/src/main/java/org/radarcns/stream/collector/NumericAggregateCollector.java
@@ -271,7 +271,7 @@ public class NumericAggregateCollector implements RecordCollector {
         /**
          * For backwards compatibility purposes, convert a full history to a reservoir.
          * @param history stored history.
-         * @return
+         * @return the current builder.
          * @deprecated use reservoir instead.
          */
         @Deprecated

--- a/src/main/java/org/radarcns/stream/collector/NumericAggregateCollector.java
+++ b/src/main/java/org/radarcns/stream/collector/NumericAggregateCollector.java
@@ -268,6 +268,13 @@ public class NumericAggregateCollector implements RecordCollector {
             return this;
         }
 
+        /**
+         * For backwards compatibility purposes, convert a full history to a reservoir.
+         * @param history stored history.
+         * @return
+         * @deprecated use reservoir instead.
+         */
+        @Deprecated
         @JsonSetter
         public Builder history(List<Double> history) {
             min(history.get(0));

--- a/src/main/java/org/radarcns/stream/collector/UniformSamplingReservoir.java
+++ b/src/main/java/org/radarcns/stream/collector/UniformSamplingReservoir.java
@@ -117,7 +117,7 @@ public class UniformSamplingReservoir {
         } else {
             quartiles = new ArrayList<>(3);
             for (int i = 1; i <= 3; i++) {
-                double pos = i * (length + 1) / 4.0d;  // == i * 25 * (length + 1) / 100
+                double pos = i * (length + 1) * 0.25d; // 25 percentile steps
                 int intPos = (int) pos;
                 if (intPos == 0) {
                     quartiles.add(samples.get(0));

--- a/src/main/java/org/radarcns/stream/collector/UniformSamplingReservoir.java
+++ b/src/main/java/org/radarcns/stream/collector/UniformSamplingReservoir.java
@@ -1,0 +1,149 @@
+package org.radarcns.stream.collector;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class UniformSamplingReservoir {
+    private final List<Double> samples;
+    private final int maxSize;
+    private int count;
+    private static final int MAX_SIZE_DEFAULT = 999;
+
+    public UniformSamplingReservoir() {
+        this(Collections.<Double>emptyList(), 0, MAX_SIZE_DEFAULT);
+    }
+
+    public UniformSamplingReservoir(List<Double> allSamples) {
+        this(allSamples, allSamples.size(), MAX_SIZE_DEFAULT);
+    }
+
+    @JsonCreator
+    public UniformSamplingReservoir(
+            @JsonProperty("samples") List<Double> samples,
+            @JsonProperty("count") int count,
+            @JsonProperty("maxSize") int maxSize) {
+        this.samples = new ArrayList<>(Objects.requireNonNull(samples));
+
+        if (maxSize <= 0) {
+            throw new IllegalArgumentException("Reservoir size must be strictly positive");
+        }
+        this.maxSize = maxSize;
+
+        if (count < 0) {
+            throw new IllegalArgumentException("Reservoir size must be positive");
+        }
+        this.count = count;
+
+
+        int toRemove = this.samples.size() - maxSize;
+        if (toRemove > 0) {
+            ThreadLocalRandom random = ThreadLocalRandom.current();
+            for (int i = 0; i < toRemove; i++) {
+                this.samples.remove(random.nextInt(this.samples.size()));
+            }
+        }
+        Collections.sort(this.samples);
+    }
+
+    public void add(double value) {
+        boolean doAdd;
+        int removeIndex;
+
+        if (count < maxSize) {
+            doAdd = true;
+        } else {
+            removeIndex = ThreadLocalRandom.current().nextInt(count);
+            if (removeIndex < maxSize) {
+                samples.remove(removeIndex);
+                doAdd = true;
+            } else {
+                doAdd = false;
+            }
+        }
+
+        if (doAdd) {
+            int index = Collections.binarySearch(samples, value);
+            if (index >= 0) {
+                samples.add(index, value);
+            } else {
+                samples.add(-index - 1, value);
+            }
+        }
+
+        count++;
+    }
+
+    public List<Double> getQuartiles() {
+        int length = samples.size();
+
+        List<Double> quartiles;
+        if (length == 1) {
+            Double elem = samples.get(0);
+            quartiles = Arrays.asList(elem, elem, elem);
+        } else {
+            quartiles = new ArrayList<>(3);
+            for (int i = 1; i <= 3; i++) {
+                double pos = i * (length + 1) / 4.0d;  // == i * 25 * (length + 1) / 100
+                int intPos = (int) pos;
+                if (intPos == 0) {
+                    quartiles.add(samples.get(0));
+                } else if (intPos == length) {
+                    quartiles.add(samples.get(length - 1));
+                } else {
+                    double diff = pos - intPos;
+                    double base = samples.get(intPos - 1);
+                    quartiles.add(base + diff * (samples.get(intPos) - base));
+                }
+            }
+        }
+
+        return quartiles;
+    }
+
+    public List<Double> getSamples() {
+        return Collections.unmodifiableList(samples);
+    }
+
+    public int getMaxSize() {
+        return maxSize;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UniformSamplingReservoir that = (UniformSamplingReservoir) o;
+        return count == that.count
+                && maxSize == that.maxSize
+                && Objects.equals(samples, that.samples);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(samples, maxSize, count);
+    }
+
+    @Override
+    public String toString() {
+        return "UniformSamplingReservoir{"
+                + "samples=" + samples
+                + ", maxSize=" + maxSize
+                + ", count=" + count
+                + '}';
+    }
+}

--- a/src/main/java/org/radarcns/stream/collector/UniformSamplingReservoir.java
+++ b/src/main/java/org/radarcns/stream/collector/UniformSamplingReservoir.java
@@ -10,20 +10,41 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 
+/**
+ * Uniform sampling reservoir for streaming. This should capture the input distribution in order
+ * to compute quartiles, using so-called Algorithm R.
+ *
+ * <p>The maximum size of the reservoir can be increased to get more accurate quartile estimations.
+ * As long as the number of samples is lower than the maximum size of the reservoir, the quartiles
+ * are computed exactly.
+ */
 public class UniformSamplingReservoir {
     private final List<Double> samples;
     private final int maxSize;
     private int count;
     private static final int MAX_SIZE_DEFAULT = 999;
 
+    /** Empty reservoir with default maximum size. */
     public UniformSamplingReservoir() {
         this(Collections.<Double>emptyList(), 0, MAX_SIZE_DEFAULT);
     }
 
-    public UniformSamplingReservoir(List<Double> allSamples) {
-        this(allSamples, allSamples.size(), MAX_SIZE_DEFAULT);
+    /**
+     * Create a reservoir that samples from given values.
+     * @param allValues list of values to sample from.
+     * @throws NullPointerException if given allValues are {@code null}.
+     */
+    public UniformSamplingReservoir(List<Double> allValues) {
+        this(allValues, allValues.size(), MAX_SIZE_DEFAULT);
     }
 
+    /**
+     * Create a reservoir that samples from given values.
+     * @param samples list of values to sample from.
+     * @param count current size of the number of samples that the reservoir represents.
+     * @param maxSize maximum reservoir size.
+     * @throws NullPointerException if given allValues are {@code null}
+     */
     @JsonCreator
     public UniformSamplingReservoir(
             @JsonProperty("samples") List<Double> samples,
@@ -52,6 +73,7 @@ public class UniformSamplingReservoir {
         Collections.sort(this.samples);
     }
 
+    /** Add a sample to the reservoir. */
     public void add(double value) {
         boolean doAdd;
         int removeIndex;
@@ -80,6 +102,11 @@ public class UniformSamplingReservoir {
         count++;
     }
 
+    /**
+     * Get the quartiles of the underlying distribution. If the number of samples is larger than
+     * the maximum size of the reservoir, this will be an estimate.
+     * @return list with size three, of the 25, 50 and 75 percentiles.
+     */
     public List<Double> getQuartiles() {
         int length = samples.size();
 
@@ -107,14 +134,17 @@ public class UniformSamplingReservoir {
         return quartiles;
     }
 
+    /** Get the currently stored samples. */
     public List<Double> getSamples() {
         return Collections.unmodifiableList(samples);
     }
 
+    /** Get the maximum size of this reservoir. */
     public int getMaxSize() {
         return maxSize;
     }
 
+    /** Get the number of samples that are being represented by the reservoir. */
     public int getCount() {
         return count;
     }

--- a/src/test/java/org/radarcns/stream/collector/AggregateListCollectorTest.java
+++ b/src/test/java/org/radarcns/stream/collector/AggregateListCollectorTest.java
@@ -31,7 +31,11 @@ public class AggregateListCollectorTest {
                 new String[]{"a", "b", "c", "d"});
         double[] arrayvalues = {0.15d, 1.0d, 2.0d, 3.0d};
         arrayCollector.add(arrayvalues);
-        assertEquals("[DoubleValueCollector{name=a, min=0.15, max=0.15, sum=0.15, count=1, mean=0.15, quartile=[0.15, 0.15, 0.15], history=[0.15]}, DoubleValueCollector{name=b, min=1.0, max=1.0, sum=1.0, count=1, mean=1.0, quartile=[1.0, 1.0, 1.0], history=[1.0]}, DoubleValueCollector{name=c, min=2.0, max=2.0, sum=2.0, count=1, mean=2.0, quartile=[2.0, 2.0, 2.0], history=[2.0]}, DoubleValueCollector{name=d, min=3.0, max=3.0, sum=3.0, count=1, mean=3.0, quartile=[3.0, 3.0, 3.0], history=[3.0]}]" , arrayCollector.toString());
+        assertEquals(4, arrayCollector.getCollectors().size());
+        assertEquals(0.15, arrayCollector.getCollectors().get(0).getMin(), 0.0d);
+        assertEquals(1.0, arrayCollector.getCollectors().get(1).getMin(), 0.0d);
+        assertEquals(2.0, arrayCollector.getCollectors().get(2).getMin(), 0.0d);
+        assertEquals(3.0, arrayCollector.getCollectors().get(3).getMin(), 0.0d);
     }
 
     @Test
@@ -39,6 +43,10 @@ public class AggregateListCollectorTest {
         AggregateListCollector arrayCollector = new AggregateListCollector(new String[] {"x", "y", "z"},
                 EmpaticaE4Acceleration.getClassSchema());
         arrayCollector.add(new EmpaticaE4Acceleration(0d, 0d, 0.15f, 1.0f, 2.0f));
-        assertEquals("[DoubleValueCollector{name=x, min=0.15, max=0.15, sum=0.15, count=1, mean=0.15, quartile=[0.15, 0.15, 0.15], history=[0.15]}, DoubleValueCollector{name=y, min=1.0, max=1.0, sum=1.0, count=1, mean=1.0, quartile=[1.0, 1.0, 1.0], history=[1.0]}, DoubleValueCollector{name=z, min=2.0, max=2.0, sum=2.0, count=1, mean=2.0, quartile=[2.0, 2.0, 2.0], history=[2.0]}]" , arrayCollector.toString());
+
+        assertEquals(3, arrayCollector.getCollectors().size());
+        assertEquals(0.15, arrayCollector.getCollectors().get(0).getMin(), 0.0d);
+        assertEquals(1.0, arrayCollector.getCollectors().get(1).getMin(), 0.0d);
+        assertEquals(2.0, arrayCollector.getCollectors().get(2).getMin(), 0.0d);
     }
 }

--- a/src/test/java/org/radarcns/stream/collector/UniformSamplingReservoirTest.java
+++ b/src/test/java/org/radarcns/stream/collector/UniformSamplingReservoirTest.java
@@ -1,0 +1,70 @@
+package org.radarcns.stream.collector;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.*;
+
+public class UniformSamplingReservoirTest {
+    @Test
+    public void add() {
+        UniformSamplingReservoir reservoir = new UniformSamplingReservoir(Arrays.asList(0.1, 0.3, 0.5), 3, 3);
+        reservoir.add(0.7);
+        assertEquals(3, reservoir.getSamples().size());
+        assertEquals(3, reservoir.getMaxSize());
+        reservoir.add(0.7);
+        assertEquals(3, reservoir.getSamples().size());
+        reservoir.add(0.7);
+        assertEquals(3, reservoir.getSamples().size());
+    }
+
+    @Test
+    public void addRandom() {
+        UniformSamplingReservoir reservoir = new UniformSamplingReservoir(Collections.<Double>emptyList(), 0, 50);
+
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        for (int i = 0; i < 100; i++) {
+            reservoir.add(random.nextDouble(-1.0, 1.0));
+            assertTrue(isOrdered(reservoir.getSamples()));
+            assertTrue(reservoir.getSamples().size() <= 50);
+        }
+        assertEquals(50, reservoir.getSamples().size());
+    }
+
+    @Test
+    public void addFromRandom() {
+        UniformSamplingReservoir reservoir = new UniformSamplingReservoir(Collections.<Double>emptyList(), 0, 50);
+
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+
+        double[] chooseFrom = {-0.1, Double.NEGATIVE_INFINITY, Double.NaN, 1.0};
+
+        for (int i = 0; i < 100; i++) {
+            reservoir.add(chooseFrom[random.nextInt(chooseFrom.length)]);
+            assertTrue(isOrdered(reservoir.getSamples()));
+            assertTrue(reservoir.getSamples().size() <= 50);
+        }
+        assertEquals(50, reservoir.getSamples().size());
+    }
+
+    private static <T extends Comparable<T>> boolean isOrdered(List<T> list) {
+        Iterator<T> iterator = list.iterator();
+        if (!iterator.hasNext()) {
+            return true;
+        }
+        T previous = iterator.next();
+        while (iterator.hasNext()) {
+            T current = iterator.next();
+            if (previous.compareTo(current) > 0) {
+                return false;
+            }
+            previous = current;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
Use a [Algorithm R uniform random sampling reservoir](https://en.wikipedia.org/wiki/Reservoir_sampling#Algorithm_R) to estimate quartiles. This should fix RADAR-base/radar-backend#60, where the large size of the cumulated history causes persistence failures.

Algorithm R should provide a uniform random sample over a stream. Quartiles will be well-represented as long as the values in the stream themselves come from a relatively steady distribution. The reservoir maximum size can be set to higher values to get higher accuracy results.