### PR TITLE
Micro-optimization of uniform sampling reservoir

### DIFF
--- a/src/main/java/org/radarcns/stream/collector/NumericAggregateCollector.java
+++ b/src/main/java/org/radarcns/stream/collector/NumericAggregateCollector.java
@@ -276,9 +276,9 @@ public class NumericAggregateCollector implements RecordCollector {
          */
         @Deprecated
         @JsonSetter
-        public Builder history(List<Double> history) {
-            min(history.get(0));
-            max(history.get(history.size() - 1));
+        public Builder history(double[] history) {
+            min(history[0]);
+            max(history[history.length - 1]);
             reservoir(new UniformSamplingReservoir(history));
             return this;
         }

--- a/src/test/java/org/radarcns/stream/collector/NumericAggregateCollectorTest.java
+++ b/src/test/java/org/radarcns/stream/collector/NumericAggregateCollectorTest.java
@@ -171,7 +171,7 @@ public class NumericAggregateCollectorTest {
         mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
 
         valueCollector = new NumericAggregateCollector.Builder("test")
-                .history(Arrays.asList(-1d, 15d))
+                .history(new double[] {-1d, 15d})
                 .sum(BigDecimal.valueOf(14))
                 .build();
 
@@ -183,7 +183,7 @@ public class NumericAggregateCollectorTest {
     @Test
     public void testReservoirBuilder() {
         valueCollector = new NumericAggregateCollector.Builder("test")
-                .reservoir(new UniformSamplingReservoir(Arrays.asList(-1d, 15d), 2, 1))
+                .reservoir(new UniformSamplingReservoir(new double[] {-1d, 15d}, 2, 1))
                 .build();
 
         assertEquals(2, valueCollector.getCount());
@@ -193,7 +193,7 @@ public class NumericAggregateCollectorTest {
     @Test
     public void testReservoirBuilderUnlimited() {
         valueCollector = new NumericAggregateCollector.Builder("name")
-                .reservoir(new UniformSamplingReservoir(Arrays.asList(-1d, 15d), 2, 1000))
+                .reservoir(new UniformSamplingReservoir(new double[] {-1d, 15d}, 2, 1000))
                 .build();
 
         assertEquals(2, valueCollector.getCount());

--- a/src/test/java/org/radarcns/stream/collector/UniformSamplingReservoirTest.java
+++ b/src/test/java/org/radarcns/stream/collector/UniformSamplingReservoirTest.java
@@ -2,18 +2,17 @@ package org.radarcns.stream.collector;
 
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class UniformSamplingReservoirTest {
     @Test
     public void add() {
-        UniformSamplingReservoir reservoir = new UniformSamplingReservoir(Arrays.asList(0.1, 0.3, 0.5), 3, 3);
+        UniformSamplingReservoir reservoir = new UniformSamplingReservoir(new double[] {0.1, 0.3, 0.5}, 3, 3);
         reservoir.add(0.7);
         assertEquals(3, reservoir.getSamples().size());
         assertEquals(3, reservoir.getMaxSize());
@@ -25,7 +24,7 @@ public class UniformSamplingReservoirTest {
 
     @Test
     public void addRandom() {
-        UniformSamplingReservoir reservoir = new UniformSamplingReservoir(Collections.<Double>emptyList(), 0, 50);
+        UniformSamplingReservoir reservoir = new UniformSamplingReservoir(new double[0], 0, 50);
 
         ThreadLocalRandom random = ThreadLocalRandom.current();
         for (int i = 0; i < 100; i++) {
@@ -38,7 +37,7 @@ public class UniformSamplingReservoirTest {
 
     @Test
     public void addFromRandom() {
-        UniformSamplingReservoir reservoir = new UniformSamplingReservoir(Collections.<Double>emptyList(), 0, 50);
+        UniformSamplingReservoir reservoir = new UniformSamplingReservoir(new double[0], 0, 50);
 
         ThreadLocalRandom random = ThreadLocalRandom.current();
 


### PR DESCRIPTION
- use primitive double arrays instead of lists
- merge add and remove operations into a single operation

@yatharthranjan feel free to test if this improves stream performance. If not, performance issues lie elsewhere.