### PR TITLE
Only serialize used part of the uniform sampling reservoir

### DIFF
--- a/src/main/java/org/radarcns/stream/collector/UniformSamplingReservoir.java
+++ b/src/main/java/org/radarcns/stream/collector/UniformSamplingReservoir.java
@@ -1,6 +1,7 @@
 package org.radarcns.stream.collector;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
@@ -206,6 +207,7 @@ public class UniformSamplingReservoir {
     }
 
     /** Get the currently stored samples. */
+    @JsonGetter
     public List<Double> getSamples() {
         List<Double> doubleList = new ArrayList<>(currentLength);
         for (int i = 0; i < currentLength; i++) {


### PR DESCRIPTION
@yatharthranjan for small sampling sizes, this should decrease the serialization/deserialization time. This ensures that only the used part of the reservoir gets serialized, and not the allocated part.