### PR TITLE
Refresh schema IDs daily.

### DIFF
--- a/src/main/java/org/radarcns/producer/rest/SchemaRetriever.java
+++ b/src/main/java/org/radarcns/producer/rest/SchemaRetriever.java
@@ -118,10 +118,7 @@ public class SchemaRetriever implements Closeable {
         TimedSchemaMetadata value = cache.get(subject);
         if (value == null || value.isExpired()) {
             value = new TimedSchemaMetadata(retrieveSchemaMetadata(subject, version));
-            TimedSchemaMetadata oldValue = cache.putIfAbsent(subject, value);
-            if (oldValue != null) {
-                value = oldValue;
-            }
+            cache.put(subject, value);
         }
         return value.metadata;
     }


### PR DESCRIPTION
Only cache schema IDs for a single day, after that request for the latest schema IDs.