### PR TITLE
Release 0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.radarbase', name: 'radar-commons', version: '0.12.3'
+    implementation group: 'org.radarbase', name: 'radar-commons', version: '0.13.0'
 }
 ```
 
@@ -69,7 +69,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.radarbase', name: 'radar-commons-server', version: '0.12.3'
+    implementation group: 'org.radarbase', name: 'radar-commons-server', version: '0.13.0'
 }
 ```
 
@@ -83,7 +83,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation group: 'org.radarbase', name: 'radar-commons-testing', version: '0.12.3'
+    testImplementation group: 'org.radarbase', name: 'radar-commons-testing', version: '0.13.0'
 }
 ```
 
@@ -96,7 +96,7 @@ repositories {
 }
 
 dependencies {
-    runtimeOnly group: 'org.radarbase', name: 'radar-commons-unsafe', version: '0.12.3'
+    runtimeOnly group: 'org.radarbase', name: 'radar-commons-unsafe', version: '0.13.0'
 }
 ```
 
@@ -121,7 +121,7 @@ configurations.all {
 }
 
 dependencies {
-    compile group: 'org.radarbase', name: 'radar-commons', version: '0.12.4-SNAPSHOT'
+    compile group: 'org.radarbase', name: 'radar-commons', version: '0.13.1-SNAPSHOT'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
     // Configuration                                                             //
     //---------------------------------------------------------------------------//
 
-    version = '0.12.3'
+    version = '0.12.4-SNAPSHOT'
     group = 'org.radarbase'
     ext.githubRepoName = 'RADAR-base/radar-commons'
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
     // Configuration                                                             //
     //---------------------------------------------------------------------------//
 
-    version = '0.12.4-SNAPSHOT'
+    version = '0.13.0'
     group = 'org.radarbase'
     ext.githubRepoName = 'RADAR-base/radar-commons'
 

--- a/radar-commons-unsafe/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/radar-commons-unsafe/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -188,7 +188,7 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
   }
 
   /**
-   * Normalizes the reader schema, puts the resolved schema into the cache. 
+   * Normalizes the reader schema, puts the resolved schema into the cache.
    * <li>
    * <ul>if the reader schema is provided, use the provided one</ul>
    * <ul>if the reader schema is cached for the writer schema full name, use the cached value</ul>

--- a/radar-commons/src/main/java/org/radarbase/producer/rest/AvroDataMapperFactory.java
+++ b/radar-commons/src/main/java/org/radarbase/producer/rest/AvroDataMapperFactory.java
@@ -3,7 +3,6 @@ package org.radarbase.producer.rest;
 import static org.apache.avro.JsonProperties.NULL_VALUE;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -142,7 +141,7 @@ public final class AvroDataMapperFactory {
                     throw new SchemaValidationException(to, from, new IllegalArgumentException(
                             "Cannot map enum symbols without default value"));
                 } else {
-                    final GenericEnumSymbol symbol = new GenericData.EnumSymbol(to, defaultString);
+                    GenericEnumSymbol<?> symbol = new GenericData.EnumSymbol(to, defaultString);
                     return obj -> {
                         String value = obj.toString();
                         if (to.hasEnumSymbol(value)) {
@@ -304,7 +303,7 @@ public final class AvroDataMapperFactory {
         final AvroDataMapper subMapper = createMapper(from.getElementType(), to.getElementType(),
                 null);
         return obj -> {
-            List array = (List) obj;
+            List<?> array = (List<?>) obj;
             List<Object> toArray = new ArrayList<>(array.size());
             for (Object val : array) {
                 toArray.add(subMapper.convertAvro(val));
@@ -356,11 +355,9 @@ public final class AvroDataMapperFactory {
         } else if (to.getType() == Type.STRING) {
             final Encoder encoder = Base64.getEncoder();
             if (from.getType() == Type.FIXED) {
-                return object -> new String(encoder.encode(((Fixed) object).bytes()),
-                        StandardCharsets.UTF_8);
+                return object -> encoder.encode(((Fixed) object).bytes());
             } else {
-                return object -> new String(encoder.encode(((ByteBuffer) object).array()),
-                        StandardCharsets.UTF_8);
+                return object -> encoder.encode(((ByteBuffer) object).array());
             }
         } else {
             throw new SchemaValidationException(to, from,

--- a/radar-commons/src/main/java/org/radarbase/producer/rest/BinaryRecordRequest.java
+++ b/radar-commons/src/main/java/org/radarbase/producer/rest/BinaryRecordRequest.java
@@ -41,7 +41,7 @@ public class BinaryRecordRequest<K, V> implements RecordRequest<K, V> {
     private RecordData<K, V> records;
     private BinaryEncoder binaryEncoder;
     private final AvroWriter<V> valueEncoder;
-    private int sourceIdPos;
+    private final int sourceIdPos;
 
     /**
      * Binary record request for given topic.

--- a/radar-commons/src/main/java/org/radarbase/producer/rest/SchemaRestClient.java
+++ b/radar-commons/src/main/java/org/radarbase/producer/rest/SchemaRestClient.java
@@ -1,0 +1,117 @@
+package org.radarbase.producer.rest;
+
+import java.io.IOException;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okio.BufferedSink;
+import org.apache.avro.Schema;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.radarbase.util.Strings;
+
+/** REST client for Confluent schema registry. */
+public class SchemaRestClient {
+    private final RestClient client;
+
+    public SchemaRestClient(RestClient client) {
+        this.client = client;
+    }
+
+    /** Retrieve schema metadata from server. */
+    public ParsedSchemaMetadata retrieveSchemaMetadata(String subject, int version)
+            throws JSONException, IOException {
+        boolean isLatest = version <= 0;
+
+        StringBuilder pathBuilder = new StringBuilder(50)
+                .append("/subjects/")
+                .append(subject)
+                .append("/versions/");
+
+        if (isLatest) {
+            pathBuilder.append("latest");
+        } else {
+            pathBuilder.append(version);
+        }
+
+        JSONObject node = requestJson(pathBuilder.toString());
+        int newVersion = isLatest ? node.getInt("version") : version;
+        int schemaId = node.getInt("id");
+        Schema schema = parseSchema(node.getString("schema"));
+        return new ParsedSchemaMetadata(schemaId, newVersion, schema);
+    }
+
+    private JSONObject requestJson(String path) throws IOException {
+        Request request = client.requestBuilder(path)
+                .addHeader("Accept", "application/json")
+                .build();
+
+        String response = client.requestString(request);
+        return new JSONObject(response);
+    }
+
+
+    /** Parse a schema from string. */
+    public Schema parseSchema(String schemaString) {
+        Schema.Parser parser = new Schema.Parser();
+        return parser.parse(schemaString);
+    }
+
+    /** Add a schema to a subject. */
+    public int addSchema(String subject, Schema schema) throws IOException {
+        Request request = client.requestBuilder("/subjects/" + subject + "/versions")
+                .addHeader("Accept", "application/json")
+                .post(new SchemaRequestBody(schema))
+                .build();
+
+        String response = client.requestString(request);
+        JSONObject node = new JSONObject(response);
+        return node.getInt("id");
+    }
+
+    /** Request metadata for a schema on a subject. */
+    public ParsedSchemaMetadata requestMetadata(String subject, Schema schema)
+            throws IOException {
+        Request request = client.requestBuilder("/subjects/" + subject)
+                .addHeader("Accept", "application/json")
+                .post(new SchemaRequestBody(schema))
+                .build();
+
+        String response = client.requestString(request);
+        JSONObject node = new JSONObject(response);
+
+        return new ParsedSchemaMetadata(node.getInt("id"),
+                node.getInt("version"), schema);
+    }
+
+    /** Retrieve schema metadata from server. */
+    public Schema retrieveSchemaById(int id)
+            throws JSONException, IOException {
+        JSONObject node = requestJson("/schemas/ids/" + id);
+        return parseSchema(node.getString("schema"));
+    }
+
+    private static class SchemaRequestBody extends RequestBody {
+        private static final byte[] SCHEMA = Strings.utf8("{\"schema\":");
+        private static final MediaType CONTENT_TYPE = MediaType.parse(
+                "application/vnd.schemaregistry.v1+json; charset=utf-8");
+
+        private final Schema schema;
+
+        private SchemaRequestBody(Schema schema) {
+            this.schema = schema;
+        }
+
+        @Override
+        public MediaType contentType() {
+            return CONTENT_TYPE;
+        }
+
+        @Override
+        public void writeTo(BufferedSink sink) throws IOException {
+            sink.write(SCHEMA);
+            sink.writeUtf8(JSONObject.quote(schema.toString()));
+            sink.writeByte('}');
+        }
+    }
+}

--- a/radar-commons/src/main/java/org/radarbase/producer/rest/SchemaRetriever.java
+++ b/radar-commons/src/main/java/org/radarbase/producer/rest/SchemaRetriever.java
@@ -18,7 +18,9 @@ package org.radarbase.producer.rest;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -31,6 +33,7 @@ import org.json.JSONObject;
 import org.radarbase.config.ServerConfig;
 import org.radarbase.util.TimedInt;
 import org.radarbase.util.TimedValue;
+import org.radarbase.util.TimedVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -235,6 +238,34 @@ public class SchemaRetriever {
             }
         }
         idCache.put(metadata.getId(), new TimedValue<>(metadata.getSchema(), cacheValidity));
+    }
+
+    /**
+     * Remove expired entries from cache.
+     */
+    public void pruneCache() {
+        prune(schemaCache);
+        prune(idCache);
+        for (ConcurrentMap<Integer, TimedInt> versionMap : subjectVersionCache.values()) {
+            prune(versionMap);
+        }
+    }
+
+    private void prune(Map<?, ? extends TimedVariable> map) {
+        for (Entry<?, ? extends TimedVariable> entry : map.entrySet()) {
+            if (entry.getValue().isExpired()) {
+                map.remove(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    /**
+     * Remove all entries from cache.
+     */
+    public void clearCache() {
+        subjectVersionCache.clear();
+        idCache.clear();
+        schemaCache.clear();
     }
 
     /**

--- a/radar-commons/src/main/java/org/radarbase/producer/rest/TopicRequestBody.java
+++ b/radar-commons/src/main/java/org/radarbase/producer/rest/TopicRequestBody.java
@@ -26,10 +26,10 @@ import okio.BufferedSink;
  * TopicRequestData in a RequestBody.
  */
 class TopicRequestBody extends RequestBody {
-    protected final RecordRequest data;
+    protected final RecordRequest<?, ?> data;
     private final MediaType mediaType;
 
-    TopicRequestBody(RecordRequest requestData, MediaType mediaType) {
+    TopicRequestBody(RecordRequest<?, ?> requestData, MediaType mediaType) {
         this.data = requestData;
         this.mediaType = mediaType;
     }

--- a/radar-commons/src/main/java/org/radarbase/topic/AvroTopic.java
+++ b/radar-commons/src/main/java/org/radarbase/topic/AvroTopic.java
@@ -145,7 +145,7 @@ public class AvroTopic<K, V> extends KafkaTopic {
             return false;
         }
 
-        AvroTopic topic = (AvroTopic) o;
+        AvroTopic<?, ?> topic = (AvroTopic<?, ?>) o;
 
         return keyClass == topic.getKeyClass() && valueClass == topic.getValueClass();
     }

--- a/radar-commons/src/main/java/org/radarbase/util/Base64.java
+++ b/radar-commons/src/main/java/org/radarbase/util/Base64.java
@@ -25,6 +25,8 @@
 
 package org.radarbase.util;
 
+import static java.nio.charset.StandardCharsets.UTF_8;  // Since Android API 19
+
 /**
  * This class consists exclusively of static methods for obtaining
  * encoders and decoders for the Base64 encoding scheme. The
@@ -134,7 +136,7 @@ public class Base64 {
                 dst[dstP] = '=';
             }
 
-            return new String(dst);
+            return new String(dst, UTF_8);
         }
     }
 }

--- a/radar-commons/src/main/java/org/radarbase/util/Base64.java
+++ b/radar-commons/src/main/java/org/radarbase/util/Base64.java
@@ -82,7 +82,7 @@ public class Base64 {
          * index values into their "Base64 Alphabet" equivalents as specified
          * in "Table 1: The Base64 Alphabet" of RFC 2045 (and RFC 4648).
          */
-        private static final char[] BASE_64_CHAR = {
+        private static final byte[] BASE_64_CHAR = {
                 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
                 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
                 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
@@ -106,11 +106,12 @@ public class Base64 {
          *          encoded bytes.
          */
         public String encode(byte[] src) {
-            int dstLen = 4 * ((src.length + 2) / 3);
-            char[] dst = new char[dstLen];
-            int srcLen = src.length / 3 * 3;
+            int srcLen = src.length;
+            byte[] dst = new byte[4 * ((srcLen + 2) / 3)];
+            int fullDataLen = srcLen / 3 * 3;
             int dstP = 0;
-            for (int srcP = 0; srcP < srcLen; srcP += 3) {
+            int srcP = 0;
+            for (; srcP < fullDataLen; srcP += 3) {
                 int bits = (src[srcP] & 0xff) << 16
                         | (src[srcP + 1] & 0xff) << 8
                         | (src[srcP + 2] & 0xff);
@@ -119,11 +120,10 @@ public class Base64 {
                 dst[dstP++] = BASE_64_CHAR[(bits >>> 6)  & 0x3f];
                 dst[dstP++] = BASE_64_CHAR[bits & 0x3f];
             }
-            if (srcLen < src.length) {               // 1 or 2 leftover bytes
-                int srcP = srcLen;
+            if (srcP < srcLen) {               // 1 or 2 leftover bytes
                 int b0 = src[srcP++] & 0xff;
                 dst[dstP++] = BASE_64_CHAR[b0 >> 2];
-                if (srcP == src.length) {
+                if (srcP == srcLen) {
                     dst[dstP++] = BASE_64_CHAR[(b0 << 4) & 0x3f];
                     dst[dstP++] = '=';
                 } else {

--- a/radar-commons/src/main/java/org/radarbase/util/Base64.java
+++ b/radar-commons/src/main/java/org/radarbase/util/Base64.java
@@ -25,8 +25,6 @@
 
 package org.radarbase.util;
 
-import java.util.Arrays;
-
 /**
  * This class consists exclusively of static methods for obtaining
  * encoders and decoders for the Base64 encoding scheme. The
@@ -84,7 +82,7 @@ public class Base64 {
          * index values into their "Base64 Alphabet" equivalents as specified
          * in "Table 1: The Base64 Alphabet" of RFC 2045 (and RFC 4648).
          */
-        private static final byte[] BASE_64_BYTE = {
+        private static final char[] BASE_64_CHAR = {
                 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
                 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
                 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
@@ -97,10 +95,6 @@ public class Base64 {
         private Encoder() {
         }
 
-        private int outLength(int srclen) {
-            return 4 * ((srclen + 2) / 3);
-        }
-
         /**
          * Encodes all bytes from the specified byte array into a newly-allocated
          * byte array using the {@link Base64} encoding scheme. The returned byte
@@ -111,51 +105,36 @@ public class Base64 {
          * @return  A newly-allocated byte array containing the resulting
          *          encoded bytes.
          */
-        public byte[] encode(byte[] src) {
-            int len = outLength(src.length);          // dst array size
-            byte[] dst = new byte[len];
-            int ret = encode0(src, src.length, dst);
-            if (ret != dst.length) {
-                return Arrays.copyOf(dst, ret);
+        public String encode(byte[] src) {
+            int dstLen = 4 * ((src.length + 2) / 3);
+            char[] dst = new char[dstLen];
+            int srcLen = src.length / 3 * 3;
+            int dstP = 0;
+            for (int srcP = 0; srcP < srcLen; srcP += 3) {
+                int bits = (src[srcP] & 0xff) << 16
+                        | (src[srcP + 1] & 0xff) << 8
+                        | (src[srcP + 2] & 0xff);
+                dst[dstP++] = BASE_64_CHAR[(bits >>> 18) & 0x3f];
+                dst[dstP++] = BASE_64_CHAR[(bits >>> 12) & 0x3f];
+                dst[dstP++] = BASE_64_CHAR[(bits >>> 6)  & 0x3f];
+                dst[dstP++] = BASE_64_CHAR[bits & 0x3f];
             }
-            return dst;
-        }
-
-        private int encode0(byte[] src, int end, byte[] dst) {
-            int sp = 0;
-            int slen = end / 3 * 3;
-            int dp = 0;
-            while (sp < slen) {
-                int sl0 = Math.min(sp + slen, slen);
-                int dp0 = dp;
-                for (int sp0 = sp; sp0 < sl0; sp0 += 3) {
-                    int bits = (src[sp0] & 0xff) << 16
-                            | (src[sp0 + 1] & 0xff) <<  8
-                            | (src[sp0 + 2] & 0xff);
-                    dst[dp0++] = BASE_64_BYTE[(bits >>> 18) & 0x3f];
-                    dst[dp0++] = BASE_64_BYTE[(bits >>> 12) & 0x3f];
-                    dst[dp0++] = BASE_64_BYTE[(bits >>> 6)  & 0x3f];
-                    dst[dp0++] = BASE_64_BYTE[bits & 0x3f];
-                }
-                int dlen = (sl0 - sp) / 3 * 4;
-                dp += dlen;
-                sp = sl0;
-            }
-            if (sp < end) {               // 1 or 2 leftover bytes
-                int b0 = src[sp++] & 0xff;
-                dst[dp++] = BASE_64_BYTE[b0 >> 2];
-                if (sp == end) {
-                    dst[dp++] = BASE_64_BYTE[(b0 << 4) & 0x3f];
-                    dst[dp++] = '=';
-                    dst[dp++] = '=';
+            if (srcLen < src.length) {               // 1 or 2 leftover bytes
+                int srcP = srcLen;
+                int b0 = src[srcP++] & 0xff;
+                dst[dstP++] = BASE_64_CHAR[b0 >> 2];
+                if (srcP == src.length) {
+                    dst[dstP++] = BASE_64_CHAR[(b0 << 4) & 0x3f];
+                    dst[dstP++] = '=';
                 } else {
-                    int b1 = src[sp] & 0xff;
-                    dst[dp++] = BASE_64_BYTE[(b0 << 4) & 0x3f | (b1 >> 4)];
-                    dst[dp++] = BASE_64_BYTE[(b1 << 2) & 0x3f];
-                    dst[dp++] = '=';
+                    int b1 = src[srcP] & 0xff;
+                    dst[dstP++] = BASE_64_CHAR[(b0 << 4) & 0x3f | (b1 >> 4)];
+                    dst[dstP++] = BASE_64_CHAR[(b1 << 2) & 0x3f];
                 }
+                dst[dstP] = '=';
             }
-            return dp;
+
+            return new String(dst);
         }
     }
 }

--- a/radar-commons/src/main/java/org/radarbase/util/RestUtils.java
+++ b/radar-commons/src/main/java/org/radarbase/util/RestUtils.java
@@ -23,7 +23,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
@@ -40,12 +39,7 @@ public final class RestUtils {
     /** OkHttp3 default hostname verifier. */
     public static final HostnameVerifier DEFAULT_HOSTNAME_VERIFIER = OkHostnameVerifier.INSTANCE;
     /** OkHttp3 hostname verifier for unsafe connections. */
-    public static final HostnameVerifier UNSAFE_HOSTNAME_VERIFIER = new HostnameVerifier() {
-        @Override
-        public boolean verify(String hostname, SSLSession session) {
-            return true;
-        }
-    };
+    public static final HostnameVerifier UNSAFE_HOSTNAME_VERIFIER = (hostname, session) -> true;
 
     /** Unsafe OkHttp3 trust manager that trusts all certificates. */
     public static final TrustManager[] UNSAFE_TRUST_MANAGER = {

--- a/radar-commons/src/main/java/org/radarbase/util/Strings.java
+++ b/radar-commons/src/main/java/org/radarbase/util/Strings.java
@@ -17,6 +17,7 @@
 package org.radarbase.util;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.regex.Pattern;
@@ -26,7 +27,7 @@ import java.util.regex.Pattern;
  */
 @SuppressWarnings("PMD.ClassNamingConventions")
 public final class Strings {
-    private static final Charset UTF_8 = Charset.forName("UTF-8");
+    private static final Charset UTF_8 = StandardCharsets.UTF_8;
     private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 
     private Strings() {

--- a/radar-commons/src/main/java/org/radarbase/util/TimedInt.java
+++ b/radar-commons/src/main/java/org/radarbase/util/TimedInt.java
@@ -1,6 +1,6 @@
 package org.radarbase.util;
 
-public class TimedInt {
+public class TimedInt implements TimedVariable {
     public final int value;
     private final long expiry;
 
@@ -9,6 +9,7 @@ public class TimedInt {
         this.value = value;
     }
 
+    @Override
     public boolean isExpired() {
         return expiry < System.currentTimeMillis();
     }
@@ -21,7 +22,9 @@ public class TimedInt {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        return value == ((TimedInt)o).value;
+        TimedInt other = (TimedInt)o;
+        return value == other.value
+                && expiry == other.expiry;
     }
 
     @Override

--- a/radar-commons/src/main/java/org/radarbase/util/TimedInt.java
+++ b/radar-commons/src/main/java/org/radarbase/util/TimedInt.java
@@ -1,0 +1,31 @@
+package org.radarbase.util;
+
+public class TimedInt {
+    public final int value;
+    private final long expiry;
+
+    public TimedInt(int value, long validity) {
+        expiry = System.currentTimeMillis() + validity * 1000L;
+        this.value = value;
+    }
+
+    public boolean isExpired() {
+        return expiry < System.currentTimeMillis();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return value == ((TimedInt)o).value;
+    }
+
+    @Override
+    public int hashCode() {
+        return value;
+    }
+}

--- a/radar-commons/src/main/java/org/radarbase/util/TimedValue.java
+++ b/radar-commons/src/main/java/org/radarbase/util/TimedValue.java
@@ -2,7 +2,7 @@ package org.radarbase.util;
 
 import java.util.Objects;
 
-public class TimedValue<T> {
+public class TimedValue<T> implements TimedVariable {
     public final T value;
     private final long expiry;
 
@@ -11,6 +11,7 @@ public class TimedValue<T> {
         this.value = Objects.requireNonNull(value);
     }
 
+    @Override
     public boolean isExpired() {
         return expiry < System.currentTimeMillis();
     }
@@ -23,7 +24,9 @@ public class TimedValue<T> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        return value.equals(((TimedValue<?>)o).value);
+        TimedValue<?> other = (TimedValue<?>)o;
+        return value.equals(other.value)
+                && expiry == other.expiry;
     }
 
     @Override

--- a/radar-commons/src/main/java/org/radarbase/util/TimedValue.java
+++ b/radar-commons/src/main/java/org/radarbase/util/TimedValue.java
@@ -1,0 +1,33 @@
+package org.radarbase.util;
+
+import java.util.Objects;
+
+public class TimedValue<T> {
+    public final T value;
+    private final long expiry;
+
+    public TimedValue(T value, long validity) {
+        expiry = System.currentTimeMillis() + validity * 1000L;
+        this.value = Objects.requireNonNull(value);
+    }
+
+    public boolean isExpired() {
+        return expiry < System.currentTimeMillis();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return value.equals(((TimedValue<?>)o).value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/radar-commons/src/main/java/org/radarbase/util/TimedVariable.java
+++ b/radar-commons/src/main/java/org/radarbase/util/TimedVariable.java
@@ -1,0 +1,5 @@
+package org.radarbase.util;
+
+public interface TimedVariable {
+    boolean isExpired();
+}

--- a/radar-commons/src/test/java/org/radarbase/producer/rest/SchemaRestClientTest.java
+++ b/radar-commons/src/test/java/org/radarbase/producer/rest/SchemaRestClientTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 The Hyve and King's College London
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.radarbase.producer.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.radarbase.config.ServerConfig;
+
+public class SchemaRestClientTest {
+    private MockWebServer server;
+    private SchemaRestClient retriever;
+
+    @Before
+    public void setUp() {
+        server = new MockWebServer();
+        ServerConfig config = new ServerConfig();
+        config.setProtocol("http");
+        config.setHost(server.getHostName());
+        config.setPort(server.getPort());
+        config.setPath("base");
+        retriever = new SchemaRestClient(RestClient.global()
+                .server(Objects.requireNonNull(config))
+                .timeout(1L, TimeUnit.SECONDS)
+                .build());
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        server.close();
+    }
+
+    @Test
+    public void retrieveSchemaMetadata() throws Exception {
+        server.enqueue(new MockResponse().setBody("{\"id\":10,\"version\":2,\"schema\":\"\\\"string\\\"\"}"));
+        ParsedSchemaMetadata metadata = retriever.retrieveSchemaMetadata("bla-value", -1);
+        assertEquals(Integer.valueOf(10), metadata.getId());
+        assertEquals(Integer.valueOf(2), metadata.getVersion());
+        assertEquals(Schema.create(Schema.Type.STRING), metadata.getSchema());
+        assertEquals("/base/subjects/bla-value/versions/latest", server.takeRequest().getPath());
+    }
+
+
+    @Test
+    public void retrieveSchemaMetadataVersion() throws Exception {
+        server.enqueue(new MockResponse().setBody("{\"id\":10,\"version\":2,\"schema\":\"\\\"string\\\"\"}"));
+        ParsedSchemaMetadata metadata = retriever.retrieveSchemaMetadata("bla-value", 2);
+        assertEquals(Integer.valueOf(10), metadata.getId());
+        assertEquals(Integer.valueOf(2), metadata.getVersion());
+        assertEquals(Schema.create(Schema.Type.STRING), metadata.getSchema());
+        assertEquals("/base/subjects/bla-value/versions/2", server.takeRequest().getPath());
+    }
+}

--- a/radar-commons/src/test/java/org/radarbase/producer/rest/SchemaRetrieverTest.java
+++ b/radar-commons/src/test/java/org/radarbase/producer/rest/SchemaRetrieverTest.java
@@ -61,14 +61,14 @@ public class SchemaRetrieverTest {
     @Test
     public void getSchemaMetadata() throws Exception {
         server.enqueue(new MockResponse().setBody("{\"id\":10,\"version\":2,\"schema\":\"\\\"string\\\"\"}"));
-        ParsedSchemaMetadata metadata = retriever.getByVersion("bla", true, 2);
+        ParsedSchemaMetadata metadata = retriever.getBySubjectAndVersion("bla", true, 2);
         assertEquals(Integer.valueOf(10), metadata.getId());
         assertEquals(Integer.valueOf(2), metadata.getVersion());
         assertEquals(Schema.create(Schema.Type.STRING), metadata.getSchema());
         assertEquals("/base/subjects/bla-value/versions/2", server.takeRequest().getPath());
 
         // Already queried schema is cached and does not need another request
-        ParsedSchemaMetadata metadata2 = retriever.getByVersion("bla", true, 2);
+        ParsedSchemaMetadata metadata2 = retriever.getBySubjectAndVersion("bla", true, 2);
         assertEquals(Integer.valueOf(10), metadata2.getId());
         assertEquals(Integer.valueOf(2), metadata2.getVersion());
         assertEquals(Schema.create(Schema.Type.STRING), metadata2.getSchema());
@@ -77,7 +77,7 @@ public class SchemaRetrieverTest {
         // Not yet queried schema needs a new request, so if the server does not respond, an
         // IOException is thrown.
         server.enqueue(new MockResponse().setResponseCode(500));
-        assertThrows(IOException.class, () -> retriever.getByVersion("bla", false, 2));
+        assertThrows(IOException.class, () -> retriever.getBySubjectAndVersion("bla", false, 2));
     }
 
     @Test

--- a/radar-commons/src/test/java/org/radarbase/producer/rest/SchemaRetrieverTest.java
+++ b/radar-commons/src/test/java/org/radarbase/producer/rest/SchemaRetrieverTest.java
@@ -89,7 +89,7 @@ public class SchemaRetrieverTest {
         assertEquals("/base/subjects/bla-value/versions/2", server.takeRequest().getPath());
 
         // Already queried schema is cached and does not need another request
-        ParsedSchemaMetadata metadata2 = retriever.getSchemaMetadata("bla", true, -1);
+        ParsedSchemaMetadata metadata2 = retriever.getSchemaMetadata("bla", true, 2);
         assertEquals(Integer.valueOf(10), metadata2.getId());
         assertEquals(Integer.valueOf(2), metadata2.getVersion());
         assertEquals(Schema.create(Schema.Type.STRING), metadata2.getSchema());

--- a/radar-commons/src/test/java/org/radarbase/producer/rest/SchemaRetrieverTest.java
+++ b/radar-commons/src/test/java/org/radarbase/producer/rest/SchemaRetrieverTest.java
@@ -61,14 +61,14 @@ public class SchemaRetrieverTest {
     @Test
     public void getSchemaMetadata() throws Exception {
         server.enqueue(new MockResponse().setBody("{\"id\":10,\"version\":2,\"schema\":\"\\\"string\\\"\"}"));
-        ParsedSchemaMetadata metadata = retriever.getSchemaMetadata("bla", true, 2);
+        ParsedSchemaMetadata metadata = retriever.getByVersion("bla", true, 2);
         assertEquals(Integer.valueOf(10), metadata.getId());
         assertEquals(Integer.valueOf(2), metadata.getVersion());
         assertEquals(Schema.create(Schema.Type.STRING), metadata.getSchema());
         assertEquals("/base/subjects/bla-value/versions/2", server.takeRequest().getPath());
 
         // Already queried schema is cached and does not need another request
-        ParsedSchemaMetadata metadata2 = retriever.getSchemaMetadata("bla", true, 2);
+        ParsedSchemaMetadata metadata2 = retriever.getByVersion("bla", true, 2);
         assertEquals(Integer.valueOf(10), metadata2.getId());
         assertEquals(Integer.valueOf(2), metadata2.getVersion());
         assertEquals(Schema.create(Schema.Type.STRING), metadata2.getSchema());
@@ -77,7 +77,7 @@ public class SchemaRetrieverTest {
         // Not yet queried schema needs a new request, so if the server does not respond, an
         // IOException is thrown.
         server.enqueue(new MockResponse().setResponseCode(500));
-        assertThrows(IOException.class, () -> retriever.getSchemaMetadata("bla", false, 2));
+        assertThrows(IOException.class, () -> retriever.getByVersion("bla", false, 2));
     }
 
     @Test

--- a/radar-commons/src/test/java/org/radarbase/util/Base64Test.java
+++ b/radar-commons/src/test/java/org/radarbase/util/Base64Test.java
@@ -1,0 +1,25 @@
+package org.radarbase.util;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.ThreadLocalRandom;
+import kotlin.text.Charsets;
+import org.junit.Test;
+import org.radarbase.util.Base64.Encoder;
+
+public class Base64Test {
+    @Test
+    public void encoderTest() {
+        Encoder encoder = Base64.getEncoder();
+        java.util.Base64.Encoder javaEncoder = java.util.Base64.getEncoder();
+
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        for (int i = 0; i < 2_000; i++) {
+            byte[] src = new byte[i];
+            random.nextBytes(src);
+            String actual = encoder.encode(src);
+            String expected = new String(javaEncoder.encode(src), Charsets.UTF_8);
+            assertEquals(expected, actual);
+        }
+    }
+}

--- a/radar-commons/src/test/java/org/radarbase/util/Base64Test.java
+++ b/radar-commons/src/test/java/org/radarbase/util/Base64Test.java
@@ -14,7 +14,7 @@ public class Base64Test {
         java.util.Base64.Encoder javaEncoder = java.util.Base64.getEncoder();
 
         ThreadLocalRandom random = ThreadLocalRandom.current();
-        for (int i = 0; i < 2_000; i++) {
+        for (int i = 0; i < 2_000; i += 7) {
             byte[] src = new byte[i];
             random.nextBytes(src);
             String actual = encoder.encode(src);


### PR DESCRIPTION
Changes since version 0.12.3:
- Refactored SchemaRetriever. It now has more functionality (retrieving by ID), caching (version, schema and ID caching) and separated out I/O to SchemaRestClient. The cache validity is now configurable, and it can be pruned or cleared whenever necessary.
- Use Android-supported Java 8 syntax in `radar-commons`.