### PR TITLE
Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,12 @@ updates:
 - package-ecosystem: gradle
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
+  target-branch: "dev"
   ignore:
   - dependency-name: com.opencsv:opencsv
     versions:
     - "5.3"
     - "5.4"
+


### PR DESCRIPTION
This is a PR to  to run configure dependabot to run weekly and target the dev branch

I want to merge it to `master` to prevent unnecessary/incorrect PRs from dependabot, so we can incorporate the PRs into our regular release cycle.