### PR TITLE
revert "Move httpclient configuration into the config class"

### DIFF
--- a/radar-commons/src/main/java/org/radarbase/producer/schema/SchemaRetriever.kt
+++ b/radar-commons/src/main/java/org/radarbase/producer/schema/SchemaRetriever.kt
@@ -205,8 +205,8 @@ open class SchemaRetriever(config: Config) {
     @RadarProducerDsl
     class Config(
         val baseUrl: String,
-        var httpClient: HttpClient? = null,
     ) {
+        var httpClient: HttpClient? = null
         var schemaTimeout: CacheConfig = DEFAULT_SCHEMA_TIMEOUT_CONFIG
         var ioContext: CoroutineContext = Dispatchers.IO
         fun httpClient(config: HttpClientConfig<*>.() -> Unit) {


### PR DESCRIPTION
Unnecessary changes were mistakenly committed to the master branch, this PR will revert those changes. 

Since the release was not published yet no packages with version 1.1.3 were pushed yet.

There will however be some unreleased changes in the master branch until the next release, which is a bit unfortunate. to remedy this we can decide to make a somewhat redundant 1.1.3 release now.