### PR TITLE
Revert to Java 11 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 11
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2.8.0

--- a/.github/workflows/publish_snapshots.yml
+++ b/.github/workflows/publish_snapshots.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 11
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2.8.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 11
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2.8.0

--- a/.github/workflows/scheduled_snyk.yaml
+++ b/.github/workflows/scheduled_snyk.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 11
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2.8.0

--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 11
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2.8.0

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,13 +10,13 @@ repositories {
 }
 
 tasks.withType<JavaCompile> {
-    sourceCompatibility = "17"
-    targetCompatibility = "17"
+    sourceCompatibility = "11"
+    targetCompatibility = "11"
 }
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_17)
+        jvmTarget.set(JvmTarget.JVM_11)
         languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9)
         apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9)
     }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -13,7 +13,7 @@ object Versions {
         const val publishPlugin = "2.0.0-rc-1"
     }
 
-    const val java = 17
+    const val java = 11
     const val slf4j = "2.0.13"
     const val confluent = "7.6.0"
     const val kafka = "${confluent}-ce"


### PR DESCRIPTION
Due to issues like https://github.com/RADAR-base/kafka-connect-transform-keyvalue/issues/12

I want to merge this into dev so we can use snapshot dependencies in the projects where we need it.

We might consider building separate-packages/images in some way to fix this issue without having to revert our entire codebase to java 11?
