### PR TITLE
Fix ktlint version used for default slf4j version

### DIFF
--- a/radar-commons-gradle/src/main/kotlin/org/radarbase/gradle/plugin/RadarKotlinPlugin.kt
+++ b/radar-commons-gradle/src/main/kotlin/org/radarbase/gradle/plugin/RadarKotlinPlugin.kt
@@ -58,7 +58,7 @@ class RadarKotlinPlugin : Plugin<Project> {
             kotlinApiVersion.convention("")
             junitVersion.convention(Versions.junit)
             ktlintVersion.convention(Versions.ktlint)
-            slf4jVersion.convention(Versions.ktlint)
+            slf4jVersion.convention(Versions.slf4j)
             sentryEnabled.convention(false)
             sentryOrganization.convention("radar-base")
             sentryProject.convention(project.name)

--- a/radar-commons-gradle/src/main/kotlin/org/radarbase/gradle/plugin/Versions.kt
+++ b/radar-commons-gradle/src/main/kotlin/org/radarbase/gradle/plugin/Versions.kt
@@ -6,4 +6,5 @@ object Versions {
     const val ktlint = "0.50.0"
     const val java = 11
     const val junit = "5.10.0"
+    const val slf4j = "2.0.16"
 }


### PR DESCRIPTION
# Problem
By default the slf4j version is determined by the ktlint version. This is incorrect.

# Solution
The slf4j version was added to the defaults (v2.0.16) and the correct default was applied in the gradle plugin.