### PR TITLE
Set project version to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ configurations.all {
 }
 
 dependencies {
-    implementation("org.radarbase:radar-commons:1.1.3-SNAPSHOT")
+    implementation("org.radarbase:radar-commons:1.2.0")
 }
 ```
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 @Suppress("ConstPropertyName", "MemberVisibilityCanBePrivate")
 object Versions {
-    const val project = "1.1.3-SNAPSHOT"
+    const val project = "1.2.0"
 
     object Plugins {
         const val licenseReport = "2.5"

--- a/radar-commons-gradle/build.gradle.kts
+++ b/radar-commons-gradle/build.gradle.kts
@@ -177,7 +177,7 @@ tasks.withType<PublishToMavenRepository> {
 // They should be copied from the Versions.kt file directly to maintain consistency.
 @Suppress("ConstPropertyName", "MemberVisibilityCanBePrivate")
 object Versions {
-    const val project = "1.1.3-SNAPSHOT"
+    const val project = "1.2.0"
 
     object Plugins {
         const val licenseReport = "2.5"


### PR DESCRIPTION
Minor version increased because the Sentry backwards compatible feature was added.