### PR TITLE
Fix: Resolve Issues in RestKafkaSender and SchemaRetriever 

### DIFF
--- a/radar-commons/src/main/java/org/radarbase/producer/rest/AvroContentConverter.kt
+++ b/radar-commons/src/main/java/org/radarbase/producer/rest/AvroContentConverter.kt
@@ -25,17 +25,17 @@ class AvroContentConverter(
 
         return coroutineScope {
             val keySchema = async {
-                schemaRetriever.metadata(
+                schemaRetriever.getByVersion(
                     topic = value.topic.name,
                     ofValue = false,
-                    schema = value.topic.keySchema,
+                    version = -1,
                 )
             }
             val valueSchema = async {
-                schemaRetriever.metadata(
+                schemaRetriever.getByVersion(
                     topic = value.topic.name,
                     ofValue = true,
-                    schema = value.topic.valueSchema,
+                    version = -1,
                 )
             }
             val maker = if (binary) {

--- a/radar-commons/src/main/java/org/radarbase/producer/rest/RadarParameterizedType.kt
+++ b/radar-commons/src/main/java/org/radarbase/producer/rest/RadarParameterizedType.kt
@@ -1,0 +1,25 @@
+package org.radarbase.producer.rest
+
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+class RadarParameterizedType(
+    private val raw: Class<*>,
+    private val args: Array<Type>,
+    private val owner: Type? = null
+) : ParameterizedType {
+    override fun getRawType(): Type = raw
+    override fun getActualTypeArguments(): Array<Type> = args
+    override fun getOwnerType(): Type? = owner
+
+    override fun toString(): String {
+        return buildString {
+            append(raw.typeName)
+            if (args.isNotEmpty()) {
+                append('<')
+                append(args.joinToString(", ") { it.typeName })
+                append('>')
+            }
+        }
+    }
+}

--- a/radar-commons/src/main/java/org/radarbase/producer/rest/RestKafkaSender.kt
+++ b/radar-commons/src/main/java/org/radarbase/producer/rest/RestKafkaSender.kt
@@ -61,8 +61,6 @@ import org.radarbase.topic.AvroTopic
 import org.radarbase.util.RadarProducerDsl
 import org.slf4j.LoggerFactory
 import java.io.IOException
-import kotlin.reflect.javaType
-import kotlin.reflect.typeOf
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -143,6 +141,16 @@ class RestKafkaSender(config: Config) : KafkaSender {
     inner class RestKafkaTopicSender<K : Any, V : Any>(
         override val topic: AvroTopic<K, V>,
     ) : KafkaTopicSender<K, V> {
+
+        val recordDataTypeInfo: TypeInfo = TypeInfo(
+            type = RecordData::class,
+            kotlinType = null,
+            reifiedType = RadarParameterizedType(
+                raw = RecordData::class.java,
+                args = arrayOf(topic.keyClass, topic.valueClass)
+            )
+        )
+
         override suspend fun send(records: RecordData<K, V>) = withContext(scope.coroutineContext) {
             try {
                 val response: HttpResponse = restClient.post {
@@ -275,7 +283,6 @@ class RestKafkaSender(config: Config) : KafkaSender {
 
     companion object {
         private val logger = LoggerFactory.getLogger(RestKafkaSender::class.java)
-        private val recordDataTypeInfo: TypeInfo
 
         val DEFAULT_TIMEOUT: Duration = 20.seconds
         val KAFKA_REST_BINARY_ENCODING = ContentType("application", "vnd.radarbase.avro.v1+binary")
@@ -283,13 +290,6 @@ class RestKafkaSender(config: Config) : KafkaSender {
         val KAFKA_REST_ACCEPT = ContentType("application", "vnd.kafka.v2+json")
         const val GZIP_CONTENT_ENCODING = "gzip"
 
-        init {
-            val kType = typeOf<RecordData<Any, Any>>()
-
-            @OptIn(ExperimentalStdlibApi::class)
-            val reifiedType = kType.javaType
-            recordDataTypeInfo = TypeInfo(RecordData::class, reifiedType, kType)
-        }
 
         fun restKafkaSender(builder: Config.() -> Unit): RestKafkaSender =
             RestKafkaSender(Config().apply(builder))


### PR DESCRIPTION
This PR addresses two key issues:

**1. `TypeInfo` Errors in `RestKafkaSender`:**
                                                                           The current approach using reflection and generics to set TypeInfo results in errors when using with `radar-commons-android`. This has been replaced with an implementation based on ParameterizedType, which is error-free.

**2. SchemaRetriever Metadata Behavior:**
                                                                            The `ContentConverters` implementation utilizes `SchemaRetriever::metadata`, which sends a POST request to the /subject/topic_name endpoint, resulting in a 503 Service Unavailable error. 
This behavior was not observed in previous versions, previously, a GET request was sent to the `/subject/topic_name-key|value` endpoint if that fails, then the POST is used.

These changes have been tested and work seamlessly with RADAR-pRMT. Suggestions for alternative solutions are welcome.


