### PR TITLE
Add Mutex.withReentrantLock to enable coroutine-friendly reentrant locking

### DIFF
--- a/radar-commons-kotlin/README.md
+++ b/radar-commons-kotlin/README.md
@@ -100,6 +100,22 @@ if (resource == null) {
 }
 ```
 
+### `Mutex.withReentrantLock`
+
+Allows reentrant locking on a [Mutex](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.sync/-mutex/) within the same coroutine using a coroutine context marker.
+
+```kotlin
+val mutex = Mutex()
+
+suspend fun safeRecursiveOperation() = mutex.withReentrantLock {
+    println("Outer lock acquired")
+    mutex.withReentrantLock {
+        println("Inner lock acquired safely")
+    }
+}
+```
+
+
 ## Ktor helpers
 
 The methods and classes in `org.radarbase.ktor.auth` help setup client credentials authentication in Ktor as used in RADAR-base.

--- a/radar-commons-kotlin/src/main/kotlin/org/radarbase/kotlin/coroutines/mutex/ReentrantMutex.kt
+++ b/radar-commons-kotlin/src/main/kotlin/org/radarbase/kotlin/coroutines/mutex/ReentrantMutex.kt
@@ -1,0 +1,56 @@
+package org.radarbase.appserver.jersey.utils
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
+
+/**
+ * Acquires a lock on the given [Mutex], allowing **reentrant locking** within the same coroutine.
+ *
+ * This function ensures that if a coroutine already holds the given [Mutex],
+ * it can safely re-enter the lock without deadlocking. This is achieved by
+ * storing a context element in the coroutine's [CoroutineContext] when the
+ * lock is first acquired, and checking for that marker in any nested calls.
+ *
+ * ### Behavior:
+ * - On first call in a coroutine, the [Mutex] is locked using [withLock], and
+ *   a marker is added to the coroutine context.
+ * - On nested calls with the same [Mutex], the marker is detected and the block
+ *   executes immediately without re-locking.
+ *
+ * ### Example:
+ * ```
+ * val mutex = Mutex()
+ *
+ * suspend fun doSomething() = mutex.withReentrantLock {
+ *     println("First level")
+ *     mutex.withReentrantLock {
+ *         println("Second level")
+ *     }
+ * }
+ * ```
+ *
+ * @param block The suspending block of code to execute under the lock.
+ * @return The result of the [block].
+ */
+suspend fun <T> Mutex.withReentrantLock(block: suspend () -> T): T {
+    val key = ReentrantMutexContextKey(this)
+
+    if (coroutineContext[key] != null) {
+        return block()
+    }
+
+    return withContext(ReentrantMutexContextElement(key)) {
+        withLock {
+            block()
+        }
+    }
+}
+
+data class ReentrantMutexContextKey(val mutex: Mutex) : CoroutineContext.Key<ReentrantMutexContextElement>
+
+class ReentrantMutexContextElement(
+    override val key: ReentrantMutexContextKey,
+) : CoroutineContext.Element


### PR DESCRIPTION
Kotlin's `Mutex` is not reentrant, unlike Java's `ReentrantLock` or `synchronized`. This PR adds a `Mutex.withReentrantLock` extension to support reentrant locking within the same coroutine.

